### PR TITLE
src/metrics: Implement info metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.11.0] - 2021-06-08
+
+- Add support for OpenMetrics Info metrics (see [PR 18]).
+
+[PR 18]: https://github.com/mxinden/rust-open-metrics-client/pull/18
+
 ## [0.10.1] - 2021-05-31
 ### Added
 - Implement `Encode` for `u32`.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "open-metrics-client"
-version = "0.10.1"
+version = "0.11.0"
 authors = ["Max Inden <mail@max-inden.de>"]
 edition = "2018"
 description = "Open Metrics client library allowing users to natively instrument applications."

--- a/README.md
+++ b/README.md
@@ -28,8 +28,6 @@ behind the Open Metrics specification. Not being compliant with all requirements
 (`MUST` and `MUST NOT`) of the specification is considered a bug and likely to
 be fixed in the future. Contributions in all forms are most welcome.
 
-- Info metric.
-
 - State set metric.
 
 - Enforce "A Histogram MetricPoint MUST contain at least one bucket".

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -5,6 +5,7 @@ pub mod exemplar;
 pub mod family;
 pub mod gauge;
 pub mod histogram;
+pub mod info;
 
 /// A metric that is aware of its Open Metrics metric type.
 pub trait TypedMetric {
@@ -16,11 +17,11 @@ pub enum MetricType {
     Counter,
     Gauge,
     Histogram,
+    Info,
     Unknown,
     // Not (yet) supported metric types.
     //
     // GaugeHistogram,
-    // Info,
     // StateSet,
     // Summary
 }

--- a/src/metrics/info.rs
+++ b/src/metrics/info.rs
@@ -1,0 +1,25 @@
+//! Module implementing an Open Metrics info metric.
+//!
+//! See [`Info`] for details.
+
+use crate::metrics::{MetricType, TypedMetric};
+
+/// Open Metrics [`Info`] metric "to expose textual information which SHOULD NOT
+/// change during process lifetime".
+///
+/// ```
+/// # use open_metrics_client::metrics::info::Info;
+///
+/// let _info = Info::new(vec![("os", "GNU/linux")]);
+/// ```
+pub struct Info<S>(S);
+
+impl<S> Info<S> {
+    pub fn new(label_set: S) -> Self {
+        Self(label_set)
+    }
+}
+
+impl<S> TypedMetric for Info<S> {
+    const TYPE: MetricType = MetricType::Info;
+}


### PR DESCRIPTION
Open Metrics `Info` metric "to expose textual information which SHOULD
NOT change during process lifetime".

```
use open_metrics_client::metrics::info::Info;

let _info = Info::new(vec![("os", "GNU/linux")]);
```